### PR TITLE
🐛스케줄링 작업 중 물품 정보를 받아오지 못하는 문제 해결

### DIFF
--- a/src/main/java/com/kcs3/bid/repository/AuctionProgressItemRepository.java
+++ b/src/main/java/com/kcs3/bid/repository/AuctionProgressItemRepository.java
@@ -25,6 +25,7 @@ public interface AuctionProgressItemRepository extends JpaRepository<AuctionProg
             "WHERE api.auctionProgressItemId = :auctionProgressItemId")
     Optional<AuctionBidHighestDto> findHighestBidByAuctionProgressItemId(@Param("auctionProgressItemId") Long auctionProgressItemId);
 
+    @Query("SELECT api FROM AuctionProgressItem api JOIN FETCH api.item WHERE api.bidFinishTime < :now")
     Optional<List<AuctionProgressItem>> findAllByBidFinishTimeBefore(LocalDateTime now);
 }
 

--- a/src/main/java/com/kcs3/bid/service/AuctionBidServiceImpl.java
+++ b/src/main/java/com/kcs3/bid/service/AuctionBidServiceImpl.java
@@ -129,17 +129,15 @@ public class AuctionBidServiceImpl implements AuctionBidService {
             log.info("현재 경매 완료된 물품이 존재하지 않습니다. - {} ", now);
 
         }
-
-
     }//end transferCompletedAuctions()
 
     @Transactional
-    protected void transferItemToComplete(AuctionProgressItem item) {
+    protected void transferItemToComplete(AuctionProgressItem progressItem) {
         try {
-            boolean isComplete = checkBidCompletionStatus(item);
-            AuctionCompleteItem completeItem = buildAuctionCompleteItem(item, isComplete);
+            boolean isComplete = checkBidCompletionStatus(progressItem);
+            AuctionCompleteItem completeItem = buildAuctionCompleteItem(progressItem, isComplete);
 
-            Item auctionItem = item.getItem();
+            Item auctionItem = progressItem.getItem();
             auctionItem.endAuction();
 
             saveAlarm(isComplete,completeItem);
@@ -147,12 +145,12 @@ public class AuctionBidServiceImpl implements AuctionBidService {
 
             itemRepository.save(auctionItem);
             auctionCompleteItemRepo.save(completeItem);
-            auctionProgressItemRepo.delete(item);
+            auctionProgressItemRepo.delete(progressItem);
         } catch (CommonException e) {
-            log.error("에러 발생 물품 {}: {}", item.getAuctionProgressItemId(), e.getMessage());
+            log.error("에러 발생 물품 {}: {}", progressItem.getAuctionProgressItemId(), e.getMessage());
             throw e;
         } catch (Exception e) {
-            log.error("에러 발생 물품 {}: {}", item.getAuctionProgressItemId(), e.getMessage());
+            log.error("에러 발생 물품 {}: {}", progressItem.getAuctionProgressItemId(), e.getMessage());
             throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }//end transferItemToComplete()


### PR DESCRIPTION
🐛경매 진행중 테이블 정보를 바탕으로 경매 아이템 테이블 정보를 가져오지 못한 문제 해결
---
경매 진행 중 테이블이 경매 물품 테이블과 fetch Lasy로 연결되어있어 경매 물품 테이블의 정보를 제대로 가져오지 못하는 문제가 있었습니다. fetch 조인을 사용하여 해당 문제를 해결하였습니다.